### PR TITLE
Update parameter imports to be @guardian/cdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 # This file is created to test the args validation logic
 # It should be removed automatically but let's gitignore it just in case
 ./I-DO-EXIST.md
+
+# IDE
+.idea

--- a/src/utils/cfn.test.ts
+++ b/src/utils/cfn.test.ts
@@ -77,7 +77,7 @@ describe('The CfnParser class', () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        '../constructs/core': {
+        '@guardian/cdk/lib/constructs/core': {
           type: importType.COMPONENT,
           components: ['GuStringParameter'],
         },
@@ -104,7 +104,7 @@ describe('The CfnParser class', () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        '../constructs/core': {
+        '@guardian/cdk/lib/constructs/core': {
           type: importType.COMPONENT,
           components: ['GuParameter'],
         },

--- a/src/utils/cfn.ts
+++ b/src/utils/cfn.ts
@@ -74,7 +74,7 @@ export class CfnParser {
       }
 
       if (parameters.type === 'String') {
-        this.imports.addImport('../constructs/core', {
+        this.imports.addImport('@guardian/cdk/lib/constructs/core', {
           type: importType.COMPONENT,
           components: ['GuStringParameter'],
         });
@@ -83,7 +83,7 @@ export class CfnParser {
           parameterType: 'GuStringParameter',
         };
       } else {
-        this.imports.addImport('../constructs/core', {
+        this.imports.addImport('@guardian/cdk/lib/constructs/core', {
           type: importType.COMPONENT,
           components: ['GuParameter'],
         });


### PR DESCRIPTION
## What does this change?

This PR updates the imports for parameters to be from `@guardian/cdk/lib/constructs/core` rather than a local path. 

## How to test

Run the migrate script against an existing repository and check the output file can import correctly.

