### PR TITLE
change allowValues to allowedValues

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -218,8 +218,8 @@ describe('The CdkBuilder class', () => {
       expect(builder.formatParam('noEcho', true)).toBe(true);
     });
 
-    test('formats allowValues values correctly', () => {
-      expect(builder.formatParam('allowValues', ['one', 'two'])).toBe(
+    test('formats allowedValues values correctly', () => {
+      expect(builder.formatParam('allowedValues', ['one', 'two'])).toBe(
         `["one","two"]`
       );
     });

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -93,53 +93,51 @@ export class CdkBuilder {
     this.code.openBlock(`const parameters =`);
 
     Object.keys(this.template.Parameters).forEach((paramName) => {
-      this.addParam(paramName, this.template.Parameters[paramName])
+      this.addParam(paramName, this.template.Parameters[paramName]);
     });
 
     this.code.closeBlock();
   }
 
   addParam(name: string, props: CdkParameterProps): void {
-      if (props.comment) {
-        this.code.line(`// ${props.comment}`);
+    if (props.comment) {
+      this.code.line(`// ${props.comment}`);
+    }
+
+    this.code.indent(`${name}: new ${props.parameterType}(this, "${name}", {`);
+
+    Object.entries(props).forEach((val) => {
+      const pKey = toCamelCase(val[0]);
+
+      if (!this.shouldSkipParamProp(pKey, val[1])) {
+        this.code.line(`${pKey}: ${this.formatParam(pKey, val[1])},`);
       }
+    });
 
-      this.code.indent(
-        `${name}: new ${props.parameterType}(this, "${name}", {`
-      );
-
-      Object.entries(props).forEach((val) => {
-        const pKey = toCamelCase(val[0]);
-
-        if (!this.shouldSkipParamProp(pKey, val[1])) {
-          this.code.line(`${pKey}: ${this.formatParam(pKey, val[1])},`);
-        }
-      });
-
-      this.code.unindent(`}),`);
+    this.code.unindent(`}),`);
   }
 
   formatParam(name: string, value: any): any {
     switch (name) {
-      case "noEcho":
-        return value
-      case "allowValues":
-          return `[${value.map((v: string) => `"${v}"`)}]`
+      case 'noEcho':
+        return value;
+      case 'allowedValues':
+        return `[${value.map((v: string) => `"${v}"`)}]`;
       default:
-        return `"${value}"`
+        return `"${value}"`;
     }
   }
 
   shouldSkipParamProp(key: string, val: any): boolean {
-    const keysToSkip = ["parameterType", "comment"]
+    const keysToSkip = ['parameterType', 'comment'];
 
-    if (keysToSkip.includes(key)) return true
+    if (keysToSkip.includes(key)) return true;
 
     // Special cases
 
-    if (key === 'type' && val === 'String') return true
+    if (key === 'type' && val === 'String') return true;
 
-    return false
+    return false;
   }
 }
 


### PR DESCRIPTION
## What does this change?

This PR fixes a typo which meant that the `allowedValues` prop was not formatted correctly. 

## How to test

- Run `yarn test` and confirm that the `formats allowedValues values correctly` test passes
- Migrate an existing stack with the `allowedValues` prop and confirm it is formatted correctly

## How can we measure success?

Any parameters with the `allowedValues` props are rendered correctly in CDK

## Have we considered potential risks?

n/a

## Images

n/a
