### PR TITLE
Use GuStack and move default imports to imports class

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -43,11 +43,11 @@ describe('The CdkBuilder class', () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import type { Construct, StackProps } from "@aws-cdk/core"`
+        `import { Construct, StackProps } from "@aws-cdk/core"`
       );
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         3,
-        `import { Stack } from "@aws-cdk/core"`
+        `import { GuStack } from "@guardian/cdk/lib/constructs/core"`
       );
     });
     test('adds imports correctly', () => {
@@ -59,7 +59,7 @@ describe('The CdkBuilder class', () => {
 
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
-        4,
+        2,
         `import { Test } from "test"`
       );
     });

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -44,10 +44,10 @@ export class CdkBuilder {
     this.addImports();
 
     this.code.openBlock(
-      `export class ${this.config.stackName} extends cdk.Stack`
+      `export class ${this.config.stackName} extends GuStack`
     );
     this.code.openBlock(
-      `constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps)`
+      `constructor(scope: Construct, id: string, props?: StackProps)`
     );
     this.code.line('super(scope, id, props)');
 
@@ -63,10 +63,6 @@ export class CdkBuilder {
   // TODO: Update this for our preferred style of imports
   addImports(): void {
     this.code.line();
-    this.code.line(
-      `import type { Construct, StackProps } from "@aws-cdk/core"`
-    );
-    this.code.line(`import { Stack } from "@aws-cdk/core"`);
     Object.keys(this.imports.imports).forEach((lib) => {
       const components = this.imports.imports[lib];
 

--- a/src/utils/cfn.test.ts
+++ b/src/utils/cfn.test.ts
@@ -56,6 +56,7 @@ describe('The CfnParser class', () => {
       };
 
       parser.imports = new Imports();
+      parser.imports.imports = {};
     });
 
     test('adds a GuStringParameter and imports for string parameters', () => {

--- a/src/utils/imports.ts
+++ b/src/utils/imports.ts
@@ -1,5 +1,8 @@
 export class Imports {
-  imports: { [lib: string]: string[] } = {};
+  imports: { [lib: string]: string[] } = {
+    "@aws-cdk/core": ["Construct", "StackProps"],
+    "@guardian/cdk/lib/constructs/core": ["GuStack"]
+  };
 
   addImport(lib: string, components: string[]): void {
     if (!this.imports[lib]) {


### PR DESCRIPTION
## What does this change?

This PR updates the created stack to extend `GuStack` as all constructs from the `@guardian/cdk` library now require this. It also moves the default imports into the `Imports` class so that all imports are in one place. This also means that we don't import from `@guardian/cdk/lib/constructs/core` twice.

## How to test

- Run `yarn test` to ensure the tests pass
- Migrate an existing stack and see that it extends `GuStack` and all components are imported correctly

## How can we measure success?

Stacks created using CDK migrator now extend the `GuStack` component which is required by constructs in the `@guardian/cdk` library.

