### PR TITLE
Fix generated styling

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -186,7 +186,7 @@ describe('The CdkBuilder class', () => {
 
     test('formats allowedValues values correctly', () => {
       expect(builder.formatParam('allowedValues', ['one', 'two'])).toBe(
-        `["one","two"]`
+        `["one", "two"]`
       );
     });
 

--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -43,11 +43,11 @@ describe('The CdkBuilder class', () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import { Construct, StackProps } from "@aws-cdk/core"`
+        `import { Construct, StackProps } from "@aws-cdk/core";`
       );
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         3,
-        `import { GuStack } from "@guardian/cdk/lib/constructs/core"`
+        `import { GuStack } from "@guardian/cdk/lib/constructs/core";`
       );
     });
     test('adds imports correctly', () => {
@@ -60,7 +60,7 @@ describe('The CdkBuilder class', () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import { Test } from "test"`
+        `import { Test } from "test";`
       );
     });
   });
@@ -111,7 +111,7 @@ describe('The CdkBuilder class', () => {
         1,
         'const parameters ='
       );
-      expect(mockedCodeMaker.closeBlock).toHaveBeenNthCalledWith(1);
+      expect(mockedCodeMaker.closeBlock).toHaveBeenNthCalledWith(1, '};');
     });
 
     test('adds parameters as required parameters object', () => {

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -27,7 +27,8 @@ export class CdkBuilder {
     this.imports = imports;
     this.template = template;
 
-    this.code = new CodeMaker();
+    this.code = new CodeMaker({ indentationLevel: 2 });
+    this.code.closeBlockFormatter = (s?: string): string => s ?? '}';
   }
 
   async constructCdkFile(): Promise<void> {
@@ -49,7 +50,7 @@ export class CdkBuilder {
     this.code.openBlock(
       `constructor(scope: Construct, id: string, props?: StackProps)`
     );
-    this.code.line('super(scope, id, props)');
+    this.code.line('super(scope, id, props);');
 
     this.addParams();
 
@@ -66,7 +67,7 @@ export class CdkBuilder {
     Object.keys(this.imports.imports).forEach((lib) => {
       const components = this.imports.imports[lib];
 
-      this.code.line(`import { ${components?.join(', ')} } from "${lib}"`);
+      this.code.line(`import { ${components?.join(', ')} } from "${lib}";`);
     });
     this.code.line();
   }
@@ -84,7 +85,7 @@ export class CdkBuilder {
       this.addParam(paramName, this.template.Parameters[paramName]);
     });
 
-    this.code.closeBlock();
+    this.code.closeBlock('};');
   }
 
   addParam(name: string, props: CdkParameterProps): void {

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -64,11 +64,15 @@ export class CdkBuilder {
   // TODO: Update this for our preferred style of imports
   addImports(): void {
     this.code.line();
-    Object.keys(this.imports.imports).forEach((lib) => {
-      const components = this.imports.imports[lib];
+    Object.keys(this.imports.imports)
+      .sort()
+      .forEach((lib) => {
+        const components = this.imports.imports[lib];
 
-      this.code.line(`import { ${components?.join(', ')} } from "${lib}";`);
-    });
+        this.code.line(
+          `import { ${components?.sort().join(', ')} } from "${lib}";`
+        );
+      });
     this.code.line();
   }
 

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -115,7 +115,7 @@ export class CdkBuilder {
       case 'noEcho':
         return value;
       case 'allowedValues':
-        return `[${value.map((v: string) => `"${v}"`)}]`;
+        return `[${value.map((v: string) => `"${v}"`).join(', ')}]`;
       default:
         return `"${value}"`;
     }


### PR DESCRIPTION
## What does this change?

This PR updates the rendering of the outputted stack to confirm to our current eslint rules for stack definitions. These changes include: 

- Sort imports by library name
- Sort components imported from a library
- Add semi-colons where required
- Set indentation size to 2
- Leave space between elements in arrays

The one case not included in this PR is using `import type { ...` when imports are only used as types. This will be included in a follow up PR as it requires wider changes to the current implementation and usage of the `Imports` class.

## How to test

Use the tool to migrate a current stack and view the lack of red squiggly lines all over your IDE (except the caveat from above).

## How can we measure success?

We stop making `eslint` sad
