### PR TITLE
Make stack name optional

### DIFF
--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -24,10 +24,9 @@ export default class CdkMigrator extends Command {
       description: 'The file to output CDK to',
     },
     {
-      // TODO: Use the output filename if this isn't provided
       name: 'stack',
-      required: true,
-      description: 'The name to give the stack',
+      required: false,
+      description: 'A name to give the stack. Defaults to match the filename.',
     },
   ];
 

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -1,5 +1,47 @@
-import { parse, validate, Config } from './args';
+import { parse, validate, Config, getStackNameFromFileName } from './args';
 import fs from 'fs';
+
+describe('The getStackNameFromFileName function', () => {
+  test('strips file extension', () => {
+    expect(getStackNameFromFileName('test.ts')).toBe('Test');
+  });
+
+  test('strips multiple extensions', () => {
+    expect(getStackNameFromFileName('test.spec.ts')).toBe('Test');
+  });
+
+  test('converts snake case to pascal case', () => {
+    expect(getStackNameFromFileName('test_name')).toBe('TestName');
+  });
+
+  test('converts kebab case to pascal case', () => {
+    expect(getStackNameFromFileName('test-name')).toBe('TestName');
+  });
+
+  test('converts camel case to pascal case', () => {
+    expect(getStackNameFromFileName('testName')).toBe('TestName');
+  });
+
+  test('converts mixed case to pascal case', () => {
+    expect(getStackNameFromFileName('this-is_aTestName')).toBe(
+      'ThisIsATestName'
+    );
+  });
+
+  test('removes any other special characters', () => {
+    expect(
+      getStackNameFromFileName('t!e@s£t$-%n^a&m*e()_-+=[]{}|\\"\';:/?><,~`')
+    ).toBe('TestName');
+  });
+
+  test('removes any spaces', () => {
+    expect(getStackNameFromFileName('test name')).toBe('TestName');
+  });
+
+  test('allows numbers', () => {
+    expect(getStackNameFromFileName('test name 1')).toBe('TestName1');
+  });
+});
 
 describe('The parse function', () => {
   const args = {
@@ -27,6 +69,19 @@ describe('The parse function', () => {
   test('pulls outs output file correctly', () => {
     expect(parse(args)).toMatchObject({
       outputFile: 'output.ts',
+    });
+  });
+
+  test('gets stack name from file if not provided', () => {
+    const args = {
+      args: {
+        template: 'template',
+        output: '/path/to/stack-name.ts',
+      },
+    };
+
+    expect(parse({ ...args })).toMatchObject({
+      stackName: 'StackName',
     });
   });
 });

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import { toPascalCase } from 'codemaker';
 
 export interface Config {
   cfnPath: string;
@@ -9,13 +10,25 @@ export interface Config {
   stackName: string;
 }
 
+export const getStackNameFromFileName = (filename: string): string => {
+  // Split on . and get first element to remove any extensions
+  // Replace anything which is a space, word char, underscore or hyphen
+  // Convert to PascalCase
+  // Remove any remaining special chars
+  return toPascalCase(
+    filename.split('.')[0].replace(/[^\w\s_-]/gi, '')
+  ).replace(/[^\w]/gi, '');
+};
+
 export const parse = ({ args }: { args: { [name: string]: any } }): Config => {
+  const outputFile = path.basename(args.output);
+
   return {
     cfnPath: args.template,
     outputPath: args.output,
     outputDir: path.dirname(args.output),
-    outputFile: path.basename(args.output),
-    stackName: args.stack,
+    outputFile: outputFile,
+    stackName: args.stack ?? getStackNameFromFileName(outputFile),
   };
 };
 


### PR DESCRIPTION
## What does this change?

This PR makes the stack name argument optional. Where a stack name is not provided, the name is derived from the output file name by converting to pascal case and removing all special characters. This allows fewer arguments to be passed in most situations, simplifying the process for the user.

## How to test

Run `yarn test` to run the test suite. Specifically, the tests for `getStackNameFromFileName` in `args.test.ts`.

## How can we measure success?

The stack name is derived from the output file name when not provided

## Have we considered potential risks?

n/a

## Images

n/a
