### PR TITLE
Don't render parameters if none exist

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -86,8 +86,18 @@ describe('The CdkBuilder class', () => {
     builder.code = (mockedCodeMaker as unknown) as CodeMaker;
 
     beforeEach(() => {
+      builder.template = template;
       clearMockedCodeMaker();
       mockAddParam.mockClear();
+    });
+
+    test('does not render anything if parameters are empty', () => {
+      builder.template = {
+        Parameters: {},
+      };
+      builder.addParams();
+
+      expect(mockedCodeMaker.line).toHaveBeenCalledTimes(0);
     });
 
     test('adds parameters comments', () => {

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -77,6 +77,8 @@ export class CdkBuilder {
   }
 
   addParams(): void {
+    if (!Object.keys(this.template.Parameters).length) return;
+
     this.code.line();
     this.code.line('/* Parameters */');
 


### PR DESCRIPTION
## What does this change?

This PR modifies the `addParams` function of the `CDKBuilder` to not render anything if no parameters exist. 

Previously the following would have been rendered

```
/* Parameters */
// TODO: Consider if any of the helper classes in components/core/parameters.ts file could be used here
const parameters = {
};
```

## How to test

Run `yarn test` and check the output of the `addParams function` section in `cdk.test.ts`

## How can we measure success?

The parameters boilerplate is only rendered when the template contains parameters.

## Have we considered potential risks?

n/a

## Images

n/a
