### PR TITLE
Expect an App instead of a Construct in the Stack

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -43,7 +43,7 @@ describe('The CdkBuilder class', () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import { Construct, StackProps } from "@aws-cdk/core";`
+        `import { App, StackProps } from "@aws-cdk/core";`
       );
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         3,

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -48,7 +48,7 @@ export class CdkBuilder {
       `export class ${this.config.stackName} extends GuStack`
     );
     this.code.openBlock(
-      `constructor(scope: Construct, id: string, props?: StackProps)`
+      `constructor(scope: App, id: string, props?: StackProps)`
     );
     this.code.line('super(scope, id, props);');
 

--- a/src/utils/imports.ts
+++ b/src/utils/imports.ts
@@ -1,7 +1,7 @@
 export class Imports {
   imports: { [lib: string]: string[] } = {
-    "@aws-cdk/core": ["Construct", "StackProps"],
-    "@guardian/cdk/lib/constructs/core": ["GuStack"]
+    '@aws-cdk/core': ['App', 'StackProps'],
+    '@guardian/cdk/lib/constructs/core': ['GuStack'],
   };
 
   addImport(lib: string, components: string[]): void {


### PR DESCRIPTION
## What does this change?

This PR changes the constructor of the newly created stack to accept an `App` instead of a `Construct`. This is to match the signature of the `GuStack` which it extends.

## How to test

Migrate an existing stack and verify that there are no compiler errors due to type mismatches.

## How can we measure success?

Migrated Stacks confirm to the type definitions of the class they extend

## Have we considered potential risks?

n/a

## Images

n/a

