### PR TITLE
Update parameters comment 

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -111,7 +111,11 @@ describe("The CdkBuilder class", () => {
       );
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         3,
-        "// TODO: Consider if any of the helper classes in components/core/parameters.ts file could be used here"
+        "// TODO: Consider if any of the parameter constructs from @guardian/cdk could be used here"
+      );
+      expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
+        4,
+        "// https://github.com/guardian/cdk/blob/main/src/constructs/core/parameters.ts"
       );
     });
 

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -81,7 +81,10 @@ export class CdkBuilder {
     this.code.line("/* Parameters */");
 
     this.code.line(
-      "// TODO: Consider if any of the helper classes in components/core/parameters.ts file could be used here"
+      "// TODO: Consider if any of the parameter constructs from @guardian/cdk could be used here"
+    );
+    this.code.line(
+      "// https://github.com/guardian/cdk/blob/main/src/constructs/core/parameters.ts"
     );
     this.code.openBlock(`const parameters =`);
 


### PR DESCRIPTION
## What does this change?

When the parameters are rendered, a comment is added to suggest to the user that higher-level constructs may be available. This PR updates the parameters comment to refer to the `@guardian/cdk` library and link to the file where those constructs are defined.
