### PR TITLE
Add type imports

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -44,7 +44,7 @@ describe("The CdkBuilder class", () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import { App, StackProps } from "@aws-cdk/core";`
+        `import type { App, StackProps } from "@aws-cdk/core";`
       );
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         3,
@@ -54,7 +54,10 @@ describe("The CdkBuilder class", () => {
     test("adds imports correctly", () => {
       const imports = new Imports();
       imports.imports = {
-        test: ["Test"],
+        test: {
+          components: ["Test"],
+          types: [],
+        },
       };
       builder.imports = imports;
 

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -65,11 +65,17 @@ export class CdkBuilder {
     Object.keys(this.imports.imports)
       .sort()
       .forEach((lib) => {
-        const components = this.imports.imports[lib];
+        const imports = this.imports.imports[lib];
 
-        this.code.line(
-          `import { ${components.sort().join(", ")} } from "${lib}";`
-        );
+        imports.types.length &&
+          this.code.line(
+            `import type { ${imports.types.sort().join(", ")} } from "${lib}";`
+          );
+
+        imports.components.length &&
+          this.code.line(
+            `import { ${imports.components.sort().join(", ")} } from "${lib}";`
+          );
       });
     this.code.line();
   }

--- a/src/utils/cfn.test.ts
+++ b/src/utils/cfn.test.ts
@@ -78,7 +78,10 @@ describe("The CfnParser class", () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        "@guardian/cdk/lib/constructs/core": ["GuStringParameter"],
+        "@guardian/cdk/lib/constructs/core": {
+          components: ["GuStringParameter"],
+          types: [],
+        },
       });
     });
 
@@ -102,7 +105,10 @@ describe("The CfnParser class", () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        "@guardian/cdk/lib/constructs/core": ["GuParameter"],
+        "@guardian/cdk/lib/constructs/core": {
+          components: ["GuParameter"],
+          types: [],
+        },
       });
     });
 

--- a/src/utils/imports.test.ts
+++ b/src/utils/imports.test.ts
@@ -6,20 +6,97 @@ describe("The Imports class", () => {
       const imports = new Imports();
       imports.addImport("test", ["one"]);
       expect(imports.imports).toMatchObject({
-        test: ["one"],
+        test: {
+          components: ["one"],
+          types: [],
+        },
       });
     });
 
-    test("merges individual components if the import has already been added using component style", () => {
+    test("adds a type import if it doesn't previously exist", () => {
+      const imports = new Imports();
+      imports.addImport("test", ["one"], true);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: [],
+          types: ["one"],
+        },
+      });
+    });
+
+    test("merges individual components if the import has already been added", () => {
       const imports = new Imports();
       imports.addImport("test", ["one"]);
       expect(imports.imports).toMatchObject({
-        test: ["one"],
+        test: {
+          components: ["one"],
+          types: [],
+        },
       });
 
       imports.addImport("test", ["two"]);
       expect(imports.imports).toMatchObject({
-        test: ["one", "two"],
+        test: {
+          components: ["one", "two"],
+          types: [],
+        },
+      });
+    });
+
+    test("merges individual types if the import has already been added", () => {
+      const imports = new Imports();
+      imports.addImport("test", ["one"], true);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: [],
+          types: ["one"],
+        },
+      });
+
+      imports.addImport("test", ["two"], true);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: [],
+          types: ["one", "two"],
+        },
+      });
+    });
+
+    test("does not add type component if normal component exists", () => {
+      const imports = new Imports();
+      imports.addImport("test", ["one"]);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: ["one"],
+          types: [],
+        },
+      });
+
+      imports.addImport("test", ["one"], true);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: ["one"],
+          types: [],
+        },
+      });
+    });
+
+    test("moves existing type import to component if added as component", () => {
+      const imports = new Imports();
+      imports.addImport("test", ["one"], true);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: [],
+          types: ["one"],
+        },
+      });
+
+      imports.addImport("test", ["one"]);
+      expect(imports.imports).toMatchObject({
+        test: {
+          components: ["one"],
+          types: [],
+        },
       });
     });
   });

--- a/src/utils/imports.ts
+++ b/src/utils/imports.ts
@@ -1,15 +1,43 @@
 export class Imports {
-  imports: Record<string, string[]> = {
-    "@aws-cdk/core": ["App", "StackProps"],
-    "@guardian/cdk/lib/constructs/core": ["GuStack"],
+  imports: Record<string, { types: string[]; components: string[] }> = {
+    "@guardian/cdk/lib/constructs/core": {
+      types: [],
+      components: ["GuStack"],
+    },
+    "@aws-cdk/core": {
+      types: ["App", "StackProps"],
+      components: [],
+    },
   };
 
-  addImport(lib: string, components: string[]): void {
+  addImport(lib: string, components: string[], type = false): void {
     if (!Object.keys(this.imports).includes(lib)) {
-      this.imports[lib] = components;
+      const imports = type
+        ? { types: components, components: [] }
+        : { types: [], components };
+
+      this.imports[lib] = imports;
       return;
     }
 
-    this.imports[lib] = [...new Set(this.imports[lib].concat(components))];
+    const imports = this.imports[lib];
+    if (type) {
+      // Check if any of the new types are already imported as components
+      // if so, don't add them as types too
+      imports.types = [
+        ...new Set(
+          imports.types.concat(
+            components.filter((c) => !imports.components.includes(c))
+          )
+        ),
+      ];
+    } else {
+      // Check if any of the new components are already imported as types
+      // if so, remove them from types before we add them to components
+      imports.types = imports.types.filter((t) => !components.includes(t));
+      imports.components = [...new Set(imports.components.concat(components))];
+    }
+
+    this.imports[lib] = imports;
   }
 }


### PR DESCRIPTION
## What does this change?

Our preferred eslint config requires that any imports only used as types are imported as `import type { Component } from 'lib'`. This PR updates the imports class to keep separate lists of type and standard components. It also updates the parsing and rendering functions accordingly.

## How to test

Run `yarn test` to see the updated tests pass. Migrate an existing stack and validate that the linter is happy.

## How can we measure success?

Imports that are only used as types are imported with the `type` flag.