### PR TITLE
Render parameters on one line if there are no props

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -159,7 +159,10 @@ describe("The CdkBuilder class", () => {
     beforeEach(clearMockedCodeMaker);
 
     test("opens and closes the parameter correctly", () => {
-      builder.addParam("test", { parameterType: "GuParameter" });
+      builder.addParam("test", {
+        parameterType: "GuParameter",
+        description: "test",
+      });
       expect(mockedCodeMaker.indent).toHaveBeenNthCalledWith(
         1,
         `test: new GuParameter(this, "test", {`
@@ -188,6 +191,16 @@ describe("The CdkBuilder class", () => {
         `description: "test",`
       );
       expect(mockedCodeMaker.line).toHaveBeenCalledTimes(1);
+    });
+
+    test("renders on one line if there are no props", () => {
+      builder.addParam("test", {
+        parameterType: "GuParameter",
+      });
+      expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
+        1,
+        `test: new GuParameter(this, "test", {}),`
+      );
     });
   });
 

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -106,19 +106,29 @@ export class CdkBuilder {
       this.code.line(`// ${props.comment}`);
     }
 
-    this.code.indent(`${name}: new ${props.parameterType}(this, "${name}", {`);
+    const propsToRender = Object.entries(props).filter(
+      ([key, val]) => !this.shouldSkipParamProp(key, val)
+    );
 
-    Object.entries(props).forEach((val) => {
-      const pKey = toCamelCase(val[0]);
+    if (!propsToRender.length) {
+      this.code.line(
+        `${name}: new ${props.parameterType}(this, "${name}", {}),`
+      );
+    } else {
+      this.code.indent(
+        `${name}: new ${props.parameterType}(this, "${name}", {`
+      );
 
-      if (!this.shouldSkipParamProp(pKey, val[1])) {
+      propsToRender.forEach(([key, val]) => {
+        const pKey = toCamelCase(key);
+
         this.code.line(
-          [`${pKey}: `, this.formatParam(pKey, val[1]), `,`].join("")
+          [`${pKey}: `, this.formatParam(pKey, val), `,`].join("")
         );
-      }
-    });
+      });
 
-    this.code.unindent(`}),`);
+      this.code.unindent(`}),`);
+    }
   }
 
   formatParam(name: string, value: unknown): unknown {


### PR DESCRIPTION
## What does this change?

The PR updates the code which renders parameters to match the linting rules if not props are present.

Previously, the parameter was rendered as

```
Test1: new GuStringParameter(this, "Test1", {
}),
```

Now it is rendered as

```
Test1: new GuStringParameter(this, "Test1", {}),
```

## How to test

Run the migration on a stack with a parameter that only has the `type: string` option set and see that it renders a `GuStringParameter` with no other options. 

## How can we measure success?

The linter is happy!

## Have we considered potential risks?

n/a

## Images

n/a
