### PR TITLE
Add init command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /package-lock.json
 /tmp
 node_modules
+!src/template/*
 
 # This file is created to test the args validation logic
 # It should be removed automatically but let's gitignore it just in case

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ node_modules
 
 # This file is created to test the args validation logic
 # It should be removed automatically but let's gitignore it just in case
-EXISTS-*.md
+EXISTS-*
 
 # IDE
 .idea

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prepack": "rm -rf lib && tsc -b && oclif-dev readme",
     "build": "yarn prepack",
     "test": "jest --detectOpenHandles --runInBand",
-    "lint": "eslint src/** --ext .ts",
+    "lint": "eslint src/** --ext .ts --no-error-on-unmatched-pattern",
     "format": "prettier --write \"src/**/*.ts\"",
     "version": "oclif-dev readme && git add README.md"
   },

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,0 +1,17 @@
+import { InitCommand } from "./init";
+
+describe("The NewCommand class", () => {
+  describe("getConfig function", () => {
+    const args = {
+      args: {
+        output: "./test",
+      },
+    };
+
+    test("pulls outs output dir correctly", () => {
+      expect(InitCommand.getConfig(args)).toMatchObject({
+        outputDir: "./test",
+      });
+    });
+  });
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,97 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+} from "fs";
+import { join } from "path";
+import { Command, flags } from "@oclif/command";
+import { checkDirectoryIsEmpty } from "../utils/args";
+
+interface InitCommandConfig {
+  outputDir: string;
+}
+
+interface InitCommandArgs {
+  output: string;
+}
+
+// TODO: Add yarn or npm flag
+// TODO: Add project name flag
+export class InitCommand extends Command {
+  static description =
+    "Creates a new directory containing boilerplate configuration";
+
+  static flags = {
+    version: flags.version({ char: "v" }),
+    help: flags.help({ char: "h" }),
+  };
+
+  static args = [
+    {
+      name: "output",
+      required: false,
+      default: "./cdk",
+      description: "The path of the new directory to create. Defaults to ./cdk",
+    },
+  ];
+
+  static getConfig = ({
+    args,
+  }: {
+    args: InitCommandArgs;
+  }): InitCommandConfig => {
+    const config = {
+      outputDir: args.output,
+    };
+
+    checkDirectoryIsEmpty(config.outputDir);
+
+    return config;
+  };
+
+  templateDir = `${__dirname}/../template`;
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- The Command class requires Promise<any> but we don't do anything async here
+  async run(): Promise<void> {
+    this.log("Starting CDK generator");
+
+    const config = InitCommand.getConfig(this.parse(InitCommand));
+
+    if (!existsSync(config.outputDir)) {
+      this.log(`Creating ${config.outputDir}`);
+      mkdirSync(config.outputDir);
+    }
+
+    this.log("Copying template files");
+    // TODO: Replace any params in files with .template extensions
+    this.copyFiles(this.templateDir, config.outputDir);
+
+    this.log("Success!");
+    // TODO: Can we do this here?
+    this.log("Run ./script/setup to get started");
+    this.log(
+      "To migrate existing stacks into your new directory you can run cdk-cli migrate"
+    );
+    this.log("To create a new stack run cdk-cli new");
+  }
+
+  copyFiles(sourcePath: string, targetPath: string): void {
+    for (const file of readdirSync(sourcePath)) {
+      const path = join(sourcePath, file);
+
+      if (lstatSync(path).isDirectory()) {
+        const nestedTargetPath = join(targetPath, file);
+        if (!existsSync(nestedTargetPath)) {
+          mkdirSync(nestedTargetPath);
+        }
+        this.copyFiles(path, nestedTargetPath);
+      } else if (path.endsWith(".template")) {
+        copyFileSync(path, join(targetPath, file.replace(".template", "")));
+      } else {
+        copyFileSync(path, join(targetPath, file));
+      }
+    }
+  }
+}

--- a/src/template/.editorconfig
+++ b/src/template/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/template/.eslintignore
+++ b/src/template/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+cdk.out
+.eslintrc.js
+jest.config.js

--- a/src/template/.eslintrc.js
+++ b/src/template/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  extends: ["@guardian/eslint-config-typescript"],
+  parserOptions: {
+    ecmaVersion: 2020,
+    tsconfigRootDir: __dirname,
+    sourceType: "module",
+    project: ["./tsconfig.eslint.json"],
+  },
+  plugins: ["@typescript-eslint"],
+  rules: {
+    "@typescript-eslint/no-inferrable-types": 0,
+    "import/no-namespace": 2,
+  },
+  ignorePatterns: ["**/*.js", "node_modules"],
+};

--- a/src/template/.gitignore.template
+++ b/src/template/.gitignore.template
@@ -1,0 +1,13 @@
+*.js
+!jest.config.js
+!eslintrc.js
+*.d.ts
+node_modules
+dist
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Parcel default cache directory
+.parcel-cache

--- a/src/template/.gitignore.template
+++ b/src/template/.gitignore.template
@@ -8,6 +8,3 @@ dist
 # CDK asset staging directory
 .cdk.staging
 cdk.out
-
-# Parcel default cache directory
-.parcel-cache

--- a/src/template/README.md
+++ b/src/template/README.md
@@ -1,0 +1,24 @@
+# Infrastructure
+
+This directory defines the components to be deployed to AWS
+
+## Useful commands
+
+We follow the [`script/task`](https://github.com/github/scripts-to-rule-them-all) pattern,
+find useful scripts within the [`script`](./script) directory for common tasks.
+
+- `./script/setup` to install dependencies
+- `./script/start` to run the Jest unit tests in watch mode
+- `./script/lint` to lint the code using ESLint
+- `./script/test` to lint, run tests and generate templates of the CDK stacks
+- `./script/build` to compile TypeScript to JS and generate templates of the CDK stacks
+- `./script/diff` to print the diff between a traditional CloudFormation template and a CDK stack
+- `./script/generate` to build a CDK stack into the `cdk.out` directory
+
+There are also some other commands defined in `package.json`, including:
+
+- `yarn lint --fix` attempt to autofix any linter errors
+- `yarn format` format the code using Prettier
+- `yarn watch` watch for changes and compile
+
+However, it's advised you configure your IDE to format on save to avoid horrible "correct linting" commits.

--- a/src/template/bin/cdk.ts.template
+++ b/src/template/bin/cdk.ts.template
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import { App } from "@aws-cdk/core";
+import { CdkStack } from "../lib/cdk-stack";
+
+const app = new App();
+new CdkStack(app, "CdkStack");

--- a/src/template/cdk.json
+++ b/src/template/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node bin/cdk.ts",
+  "context": {
+    "@aws-cdk/core:enableStackNameDuplicates": "true",
+    "aws-cdk:enableDiffNoFail": "true",
+    "@aws-cdk/core:stackRelativeExports": "true"
+  }
+}

--- a/src/template/jest.config.js
+++ b/src/template/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testMatch: ['<rootDir>/lib/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+};

--- a/src/template/lib/cdk-stack.ts.template
+++ b/src/template/lib/cdk-stack.ts.template
@@ -1,0 +1,8 @@
+import type { App, StackProps } from "@aws-cdk/core";
+import { GuStack } from "@guardian/cdk/lib/constructs/core";
+
+export class CdkStack extends GuStack {
+  constructor(scope: App, id: string, props?: StackProps) {
+    super(scope, id, props);
+  }
+}

--- a/src/template/package.json
+++ b/src/template/package.json
@@ -32,7 +32,6 @@
     "typescript": "~4.0.5"
   },
   "dependencies": {
-    "@aws-cdk/assert": "1.74.0",
     "@aws-cdk/aws-ec2": "1.74.0",
     "@aws-cdk/aws-events-targets": "1.74.0",
     "@aws-cdk/aws-iam": "~1.74 .0",

--- a/src/template/package.json
+++ b/src/template/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "cdk",
+  "version": "0.1.0",
+  "bin": {
+    "cdk": "bin/cdk.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "format": "prettier --write \"{lib,bin}/**/*.ts\"",
+    "cdk": "cdk",
+    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern"
+  },
+  "devDependencies": {
+    "@aws-cdk/assert": "1.74.0",
+    "@guardian/eslint-config-typescript": "^0.4.1",
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
+    "aws-cdk": "1.74.0",
+    "eslint": "^7.14.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prettier": "^3.1.4",
+    "jest": "^26.4.2",
+    "prettier": "^2.2.0",
+    "ts-jest": "^26.4.4",
+    "ts-node": "^9.0.0",
+    "typescript": "~4.0.5"
+  },
+  "dependencies": {
+    "@aws-cdk/assert": "1.74.0",
+    "@aws-cdk/aws-ec2": "1.74.0",
+    "@aws-cdk/aws-events-targets": "1.74.0",
+    "@aws-cdk/aws-iam": "~1.74 .0",
+    "@aws-cdk/aws-lambda": "1.74.0",
+    "@aws-cdk/aws-s3": "1.74.0",
+    "@aws-cdk/core": "1.74.0",
+    "@guardian/cdk": "^0.2.2",
+    "source-map-support": "^0.5.16"
+  }
+}

--- a/src/template/script/build
+++ b/src/template/script/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+yarn build
+
+for file in bin/*; do
+  stackName=$(basename "$file" ".ts")
+  yarn generate "$stackName"
+done

--- a/src/template/script/diff
+++ b/src/template/script/diff
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+APP=$1
+STACK=$2
+TEMPLATE_PATH=$3
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${DIR}/.."
+OUTPUT_DIR="${ROOT_DIR}/cdk.out"
+
+
+if [[ -z $APP ]]; then
+  echo -e "\033[31mPass the app you'd like to generate a diff"
+  echo -e "$0 <app> <stack> <template>\033[0m"
+  exit 1
+fi
+
+pushd "${ROOT_DIR}" > /dev/null || exit
+yarn cdk diff --app="ts-node ${ROOT_DIR}/bin/${APP}.ts" --template="${TEMPLATE_PATH}" --path-metadata false --version-reporting false "${STACK}"
+popd > /dev/null

--- a/src/template/script/generate
+++ b/src/template/script/generate
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+APP=$1
+STACK=$2
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${DIR}/.."
+OUTPUT_DIR="${ROOT_DIR}/cdk.out"
+
+
+if [[ -z $APP ]]; then
+  echo -e "\033[31mPass the app you'd like to generate Cloudformation for to this script"
+  echo -e "e.g. $0 grafana\033[0m"
+  exit 1
+fi
+
+pushd "${ROOT_DIR}" > /dev/null || exit
+yarn --silent cdk synth --app="ts-node ${ROOT_DIR}/bin/${APP}.ts"  -o "${OUTPUT_DIR}" --path-metadata false --version-reporting false ${STACK}
+popd > /dev/null

--- a/src/template/script/generate
+++ b/src/template/script/generate
@@ -11,7 +11,6 @@ OUTPUT_DIR="${ROOT_DIR}/cdk.out"
 
 if [[ -z $APP ]]; then
   echo -e "\033[31mPass the app you'd like to generate Cloudformation for to this script"
-  echo -e "e.g. $0 grafana\033[0m"
   exit 1
 fi
 

--- a/src/template/script/lint
+++ b/src/template/script/lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+yarn lint

--- a/src/template/script/setup
+++ b/src/template/script/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+yarn install

--- a/src/template/script/start
+++ b/src/template/script/start
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+yarn test:dev

--- a/src/template/script/test
+++ b/src/template/script/test
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+yarn lint
+yarn test
+
+for file in bin/*; do
+  stackName=$(basename "$file" ".ts")
+  yarn generate "$stackName"
+done

--- a/src/template/tsconfig.eslint.json
+++ b/src/template/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*", "bin/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/src/template/tsconfig.json.template
+++ b/src/template/tsconfig.json.template
@@ -1,0 +1,37 @@
+{
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  },
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"],
+    "outDir": "dist"
+  },
+  "include": ["lib/**/*", "bin/**/*"],
+  "exclude": [
+    "node_modules",
+    "cdk.out",
+    "lib/**/*.test.ts",
+    "lib/**/__snapshots__/**"
+  ]
+}

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -88,12 +88,20 @@ describe("The checkPathExists function", () => {
 });
 
 describe("The checkDirectoryIsEmpty function", () => {
+  let alreadyExists = false;
   const emptyBase = "./EXISTS-DIR";
   const emptyPath = join(emptyBase, "/empty");
   const notEmptyPath = join(emptyBase, "/not-empty");
   const notEmptyFile = join(notEmptyPath, "test.md");
 
   beforeAll(() => {
+    if (existsSync(emptyBase)) {
+      alreadyExists = true;
+      throw new Error(
+        `The ${emptyBase} directory already exists. Please remove or change the emptyBase var before continuing.`
+      );
+    }
+
     [emptyBase, emptyPath, notEmptyPath].forEach((path) => {
       if (!existsSync(path)) {
         mkdirSync(path);
@@ -106,7 +114,7 @@ describe("The checkDirectoryIsEmpty function", () => {
   });
 
   afterAll(() => {
-    if (existsSync(emptyBase)) {
+    if (!alreadyExists && existsSync(emptyBase)) {
       rmdirSync(emptyBase, { recursive: true });
     }
   });

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -1,5 +1,16 @@
-import { existsSync, unlinkSync, writeFileSync } from "fs";
-import { checkPathExists, getStackNameFromFileName } from "./args";
+import {
+  existsSync,
+  mkdirSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import {
+  checkDirectoryIsEmpty,
+  checkPathExists,
+  getStackNameFromFileName,
+} from "./args";
 
 describe("The getStackNameFromFileName function", () => {
   test("strips file extension", () => {
@@ -72,6 +83,41 @@ describe("The checkPathExists function", () => {
   test("throws an error if the file does not exist", () => {
     expect(() => checkPathExists(doesNotExistPath)).toThrow(
       "File not found - ./I-DONT-EXIST.md"
+    );
+  });
+});
+
+describe("The checkDirectoryIsEmpty function", () => {
+  const emptyBase = "./EXISTS-DIR";
+  const emptyPath = join(emptyBase, "/empty");
+  const notEmptyPath = join(emptyBase, "/not-empty");
+  const notEmptyFile = join(notEmptyPath, "test.md");
+
+  beforeAll(() => {
+    [emptyBase, emptyPath, notEmptyPath].forEach((path) => {
+      if (!existsSync(path)) {
+        mkdirSync(path);
+      }
+    });
+
+    if (!existsSync(notEmptyFile)) {
+      writeFileSync(notEmptyFile, "test");
+    }
+  });
+
+  afterAll(() => {
+    if (existsSync(emptyBase)) {
+      rmdirSync(emptyBase, { recursive: true });
+    }
+  });
+
+  test("does nothing if the directory is empty", () => {
+    expect(() => checkDirectoryIsEmpty(emptyPath)).not.toThrow();
+  });
+
+  test("throws an error if the directory is not empty", () => {
+    expect(() => checkDirectoryIsEmpty(notEmptyPath)).toThrow(
+      "Directory EXISTS-DIR/not-empty is not empty"
     );
   });
 });

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { toPascalCase } from "codemaker";
 
 export const getStackNameFromFileName = (filename: string): string => {
@@ -14,5 +14,11 @@ export const getStackNameFromFileName = (filename: string): string => {
 export const checkPathExists = (path: string): void => {
   if (!existsSync(path)) {
     throw new Error(`File not found - ${path}`);
+  }
+};
+
+export const checkDirectoryIsEmpty = (path: string): void => {
+  if (existsSync(path) && readdirSync(path).length > 0) {
+    throw new Error(`Directory ${path} is not empty`);
   }
 };


### PR DESCRIPTION
## What does this change?

This PR adds a new `init` command to CDK CLI which can be used to create the `cdk` directory. This is inspired by the same command from [aws-cdk](https://github.com/aws/aws-cdk/tree/master/packages/aws-cdk#cdk-init).

The output directory can be optionally provided or will default to `./cdk`. 

This will copy across the files in `src/template`, removing the `.template` suffix where it is present. In the future, this suffix can be used to denote parameters to be replaced at runtime. For the time being, this is mainly used to prevent functionality of config files being implemented within this repository. 

```
$ ./bin/run init                                                                                             
Starting CDK generator
Creating ./cdk
Copying template files
Success!
Run ./script/setup to get started
To migrate existing stacks into your new directory you can run cdk-cli migrate
To create a new stack run cdk-cli new
```

```
./cdk
|-- bin
|    |-- cdk.ts
|-- lib
|    |-- cdk-stack.ts
|-- script
|    | -- build  
|    | -- diff
|    | -- generate
|    | -- lint
|    | -- setup
|    | -- test
|-- .editorconfig
|-- .eslintignore
|-- .eslintrc.js
|-- .gitignore
|-- cdk.json
|-- jest.config.js
|-- package.json
|-- README.md
|-- tsconfig.eslint.json
|-- tsconfig.json
```

## How to test

Run the command locally `./bin/run init`

## How can we measure success?

CDK CLI can create new `cdk` directories will all of the recommended boilerplate, reducing the time taken to get started.