### PR TITLE
Add cancellable prompts util

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -4,11 +4,11 @@
 
 import { basename, dirname } from "path";
 import { Command, flags } from "@oclif/command";
-import prompts from "prompts";
 import { getStackNameFromFileName } from "../utils/args";
 import type { CDKTemplate } from "../utils/cdk";
 import { construct } from "../utils/cdk";
 import { Imports } from "../utils/imports";
+import { cancellablePrompts } from "../utils/prompts";
 
 interface NewCommandConfig {
   outputPath: string;
@@ -69,7 +69,7 @@ export class NewCommand extends Command {
       `New stack ${config.stackName} will be written to ${config.outputPath}`
     );
 
-    const response = await prompts({
+    const response = await cancellablePrompts({
       type: "text",
       name: "stackName",
       message: "Name of the Stack",
@@ -90,7 +90,7 @@ export class NewCommand extends Command {
   async getParameters(): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition -- while true for the win, what could go wrong?
     while (true) {
-      const nameResponse = await prompts({
+      const nameResponse = await cancellablePrompts({
         type: "text",
         name: "parameterName",
         message: "Enter the name of the parameter (or hit enter to finish):",
@@ -101,7 +101,7 @@ export class NewCommand extends Command {
       const name = nameResponse.parameterName;
 
       // TODO: Can we be more clever here about the available types?
-      const typeResponse = await prompts({
+      const typeResponse = await cancellablePrompts({
         type: "text",
         name: "parameterType",
         message: "Enter the parameter type:",

--- a/src/utils/prompts.test.ts
+++ b/src/utils/prompts.test.ts
@@ -1,0 +1,54 @@
+import prompts from "prompts";
+import type { PromptObject } from "prompts";
+import { mocked } from "ts-jest/utils";
+import { cancellablePrompts } from "./prompts";
+
+jest.mock("prompts");
+const mockedPrompts = mocked(prompts, true);
+
+describe("The cancellablePrompts function", () => {
+  beforeEach(() => {
+    mockedPrompts.mockClear();
+  });
+
+  const question: PromptObject = {
+    type: "text",
+    name: "test",
+    message: "This is a test",
+  };
+
+  test("passes through the questions with no change", async () => {
+    await cancellablePrompts(question);
+
+    expect(mockedPrompts.mock.calls[0][0]).toEqual(question);
+  });
+
+  test("adds the onCancel function", async () => {
+    await cancellablePrompts(question);
+
+    expect(Object.keys(mockedPrompts.mock.calls[0][1])).toEqual(["onCancel"]);
+  });
+
+  test("merges other options", async () => {
+    await cancellablePrompts(question, {
+      onSubmit: () => {
+        return true;
+      },
+    });
+
+    expect(Object.keys(mockedPrompts.mock.calls[0][1])).toEqual([
+      "onCancel",
+      "onSubmit",
+    ]);
+  });
+
+  test("overrides onCancel if passed through", async () => {
+    await cancellablePrompts(question, {
+      onCancel: () => "test",
+    });
+
+    expect(
+      mockedPrompts.mock.calls[0][1].onCancel({} as PromptObject, "b")
+    ).toBe("test");
+  });
+});

--- a/src/utils/prompts.test.ts
+++ b/src/utils/prompts.test.ts
@@ -26,7 +26,9 @@ describe("The cancellablePrompts function", () => {
   test("adds the onCancel function", async () => {
     await cancellablePrompts(question);
 
-    expect(Object.keys(mockedPrompts.mock.calls[0][1])).toEqual(["onCancel"]);
+    expect(
+      Object.keys(mockedPrompts.mock.calls[0][1] as Record<string, unknown>)
+    ).toEqual(["onCancel"]);
   });
 
   test("merges other options", async () => {
@@ -36,10 +38,9 @@ describe("The cancellablePrompts function", () => {
       },
     });
 
-    expect(Object.keys(mockedPrompts.mock.calls[0][1])).toEqual([
-      "onCancel",
-      "onSubmit",
-    ]);
+    expect(
+      Object.keys(mockedPrompts.mock.calls[0][1] as Record<string, unknown>)
+    ).toEqual(["onCancel", "onSubmit"]);
   });
 
   test("overrides onCancel if passed through", async () => {
@@ -47,8 +48,10 @@ describe("The cancellablePrompts function", () => {
       onCancel: () => "test",
     });
 
-    expect(
-      mockedPrompts.mock.calls[0][1].onCancel({} as PromptObject, "b")
-    ).toBe("test");
+    const options = mockedPrompts.mock.calls[0][1] as {
+      onCancel: (a: PromptObject, b: unknown) => void;
+    };
+
+    expect(options.onCancel({} as PromptObject, "b")).toBe("test");
   });
 });

--- a/src/utils/prompts.test.ts
+++ b/src/utils/prompts.test.ts
@@ -32,11 +32,7 @@ describe("The cancellablePrompts function", () => {
   });
 
   test("merges other options", async () => {
-    await cancellablePrompts(question, {
-      onSubmit: () => {
-        return true;
-      },
-    });
+    await cancellablePrompts(question, { onSubmit: () => true });
 
     expect(
       Object.keys(mockedPrompts.mock.calls[0][1] as Record<string, unknown>)

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,0 +1,14 @@
+import prompts from "prompts";
+import type { Answers, Options, PromptObject } from "prompts";
+
+export const cancellablePrompts = async <T extends string = string>(
+  p: PromptObject<T> | Array<PromptObject<T>>,
+  options: Options = {}
+): Promise<Answers<T>> => {
+  return await prompts(p, {
+    onCancel: () => {
+      throw new Error("Process aborted");
+    },
+    ...options,
+  });
+};


### PR DESCRIPTION
## What does this change?

This PR adds a new util based on the prompts function that handles being cancelled by throwing a new error to quit the process. This replaces the default behaviour of setting the value to and empty string or null when the prompt is cancelled. 

This is implemented in the `new` command when prompting for parameter names and types.

## How to test

Review the new tests and run the test suite. Run the `new` command and try cancelling one of the prompts. This should quit the process with an error message.

## How can we measure success?

When prompts are cancelled by the user, the process quits rather than trying to complete with empty values.