### PR TITLE
Don't add app and stack files when running init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -81,7 +81,9 @@ export class InitCommand extends Command {
     for (const file of readdirSync(sourcePath)) {
       const path = join(sourcePath, file);
 
-      if (lstatSync(path).isDirectory()) {
+      if (path.endsWith(".ignore")) {
+        continue;
+      } else if (lstatSync(path).isDirectory()) {
         const nestedTargetPath = join(targetPath, file);
         if (!existsSync(nestedTargetPath)) {
           mkdirSync(nestedTargetPath);

--- a/src/template/bin/.ignore
+++ b/src/template/bin/.ignore
@@ -1,0 +1,2 @@
+This file exists to ensure that the empty directory remains version controlled
+It is ignored by the `init` command when generating files

--- a/src/template/bin/cdk.ts.template
+++ b/src/template/bin/cdk.ts.template
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-import "source-map-support/register";
-import { App } from "@aws-cdk/core";
-import { CdkStack } from "../lib/cdk-stack";
-
-const app = new App();
-new CdkStack(app, "CdkStack");

--- a/src/template/lib/.ignore
+++ b/src/template/lib/.ignore
@@ -1,0 +1,2 @@
+This file exists to ensure that the empty directory remains version controlled
+It is ignored by the `init` command when generating files

--- a/src/template/lib/cdk-stack.ts.template
+++ b/src/template/lib/cdk-stack.ts.template
@@ -1,8 +1,0 @@
-import type { App, StackProps } from "@aws-cdk/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
-
-export class CdkStack extends GuStack {
-  constructor(scope: App, id: string, props?: StackProps) {
-    super(scope, id, props);
-  }
-}


### PR DESCRIPTION
## What does this change?

This PR removes the `bin/cdk.ts` and `lib/cdk-stack.ts` files from the template directory so that they are not generated when running the `init` command. This change has been made as currently the `init` command overlaps in scope with the `new` and `migrate` commands. Upon completing, the `init` command prints statements to the screen advising the use of the `new` or `migrate` commands. Running these commands generates the new files but the ones created by the `init` command remain and must be manually deleted. This change means that when users run either the `new` or `migrate` command following the completion of the `init` command, they are left in a better state. 

To support the change, new `.ignore` files have been added to the `bin/` and `lib/` directories to prevent them from being empty as then they would not be tracked by git. An extra statement has been added to the `init` command to ignore any files ending `.ignore` when generating the output.

## How to test

Run the `init` command and see that the `bin/` and `lib/` dirs are created empty.

## How can we measure success?

Users are left in a better state upon completion of `cdk-cli` commands
