### PR TITLE
Add dependabot for template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/src/template"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What does this change?

This PR adds dependabot to also check the `package.json` template file used when running the `init` command.

## How to test

Wait and see if dependabot opens any PRs

## How can we measure success?

The template file is also kept up to date with the latest deps without us having to remember to do it manually.

## Have we considered potential risks?

This may not work as we don't actually use the `package.json` in the template file.