### PR TITLE
Revert "Add dependabot for template"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/src/template"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Reverts guardian/cdk-cli#51

Sadly, this doesn't seem to work. All the PRs opened were for the main `package.json`. I'll update the template file manually for now and have a think about how we can do this auto-magically.