### PR TITLE
Update CFN yaml schema

### DIFF
--- a/src/utils/cfn.ts
+++ b/src/utils/cfn.ts
@@ -1,30 +1,15 @@
 import { readFileSync } from "fs";
 import { toCamelCase } from "codemaker";
-import { DEFAULT_SCHEMA, load, Type } from "js-yaml";
+import { load } from "js-yaml";
 import type { Imports } from "./imports";
 import { newStackImports } from "./imports";
+import { schema } from "./schema";
 import type { StackTemplate } from "./stack";
 import { camelCaseObjectKeys } from "./utils";
 
 export interface CFNTemplate {
   Parameters: Record<string, Record<string, unknown>>;
 }
-
-// TODO: Allow for all CDK tags
-const CDK_SCHEMA = DEFAULT_SCHEMA.extend([
-  new Type("!Ref", {
-    kind: "scalar",
-    construct: (data: string) => ({ Ref: data }),
-  }),
-  new Type("!Sub", {
-    kind: "scalar",
-    construct: (data: string) => ({ "Fn::Sub": data }),
-  }),
-  new Type("!GetAZs", {
-    kind: "scalar",
-    construct: (data: unknown) => ({ "Fn::GetAZs": data }),
-  }),
-]);
 
 export class CfnParser {
   cfnPath: string;
@@ -54,7 +39,7 @@ export class CfnParser {
       const f = readFileSync(this.cfnPath, "utf8");
 
       // TODO: Handle json files too
-      const cfn = load(f, { schema: CDK_SCHEMA }) as CFNTemplate;
+      const cfn = load(f, { schema }) as CFNTemplate;
 
       this.parseParameters(cfn);
     } catch (e) {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_SCHEMA, Type } from "js-yaml";
+
+// The following example shows how to implement custom tags with `js-yaml`
+// https://github.com/nodeca/js-yaml/blob/master/examples/custom_types.js
+
+enum Kinds {
+  SCALAR = "scalar",
+  SEQUENCE = "sequence",
+  MAPPING = "mapping",
+}
+
+const cfnFunctions = {
+  "!Base64": "Fn::Base64",
+  "!Cidr": "Fn::Cidr",
+  "!And": "Fn::And",
+  "!Equals": "Fn::Equals",
+  "!If": "Fn::If",
+  "!Not": "Fn::Not",
+  "!Or": "Fn::Or",
+  "!FindInMap": "Fn::FindInMap",
+  "!GetAtt": "Fn::GetAtt",
+  "!GetAZs": "Fn::GetAZs",
+  "!ImportValue": "Fn::ImportValue",
+  "!Join": "Fn::Join",
+  "!Select": "Fn::Select",
+  "!Split": "Fn::Split",
+  "!Sub": "Fn::Sub",
+  "!Transform": "Fn::Transform",
+  "!Ref": "Ref",
+};
+
+const functionKinds: Record<string, Kinds[]> = {
+  "!Base64": [Kinds.SCALAR],
+  "!Cidr": [Kinds.SEQUENCE],
+  "!And": [Kinds.SEQUENCE],
+  "!Equals": [Kinds.SEQUENCE],
+  "!If": [Kinds.SEQUENCE],
+  "!Not": [Kinds.SEQUENCE],
+  "!Or": [Kinds.SEQUENCE],
+  "!FindInMap": [Kinds.SEQUENCE],
+  "!GetAtt": [Kinds.SEQUENCE, Kinds.SCALAR],
+  "!GetAZs": [Kinds.SCALAR],
+  "!ImportValue": [Kinds.MAPPING],
+  "!Join": [Kinds.SEQUENCE],
+  "!Select": [Kinds.SEQUENCE],
+  "!Split": [Kinds.SEQUENCE],
+  "!Sub": [Kinds.SCALAR, Kinds.SEQUENCE],
+  "!Transform": [Kinds.MAPPING],
+  "!Ref": [Kinds.SCALAR],
+};
+
+export const schema = DEFAULT_SCHEMA.extend(
+  Object.entries(cfnFunctions).flatMap(([cfnKey, yamlKey]) => {
+    return functionKinds[cfnKey].map(
+      (kind: Kinds) =>
+        new Type(cfnKey, {
+          kind,
+          construct: (data: unknown) => ({ [yamlKey]: data }),
+        })
+    );
+  })
+);


### PR DESCRIPTION
## What does this change?

This refactors the custom schema for parsing cloudformation files into `schema.ts`. It also adds a list of available tags with a map of the yaml kind. The schema is created by looping through and adding entries for each.

## How to test

Try parsing templates containing and of the nearly added tags with the existing tool and view the error message. Try again with this branch and see that the process completes successfully.

## How can we measure success?

The tool is able to parse all valid cloudformation templates
