### PR TITLE
feat: Link new and migrate command with the init functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ ARGUMENTS
 OPTIONS
   -h, --help     show CLI help
   -v, --version  show CLI version
-  --multi-app
+  --init         create the cdk directory before building the app and stack files
+  --multi-app    create the stack files within sub directories as the project defines multiple apps
 ```
 
 _See code: [src/commands/migrate.ts](https://github.com/guardian/cdk-cli/blob/v0.0.0/src/commands/migrate.ts)_
@@ -112,7 +113,8 @@ ARGUMENTS
 OPTIONS
   -h, --help     show CLI help
   -v, --version  show CLI version
-  --multi-app
+  --init         create the cdk directory before building the app and stack files
+  --multi-app    create the stack files within sub directories as the project defines multiple apps
 ```
 
 _See code: [src/commands/new.ts](https://github.com/guardian/cdk-cli/blob/v0.0.0/src/commands/new.ts)_

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,19 +1,8 @@
-import {
-  copyFileSync,
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-} from "fs";
-import { join } from "path";
 import { Command, flags } from "@oclif/command";
-import { checkDirectoryIsEmpty } from "../utils/args";
+import { buildDirectory } from "../utils/init";
+import type { InitConfig } from "../utils/init";
 
-interface InitCommandConfig {
-  outputDir: string;
-}
-
-interface InitCommandArgs {
+export interface InitCommandArgs {
   output: string;
 }
 
@@ -37,25 +26,13 @@ export class InitCommand extends Command {
     },
   ];
 
-  static getConfig = ({
-    args,
-  }: {
-    args: InitCommandArgs;
-  }): InitCommandConfig => {
+  static getConfig = ({ args }: { args: InitCommandArgs }): InitConfig => {
     const config = {
       outputDir: args.output,
     };
 
-    InitCommand.validateConfig(config);
-
     return config;
   };
-
-  static validateConfig = (config: InitCommandConfig): void => {
-    checkDirectoryIsEmpty(config.outputDir);
-  };
-
-  templateDir = `${__dirname}/../template`;
 
   // eslint-disable-next-line @typescript-eslint/require-await -- The Command class requires Promise<any> but we don't do anything async here
   async run(): Promise<void> {
@@ -63,41 +40,11 @@ export class InitCommand extends Command {
 
     const config = InitCommand.getConfig(this.parse(InitCommand));
 
-    if (!existsSync(config.outputDir)) {
-      this.log(`Creating ${config.outputDir}`);
-      mkdirSync(config.outputDir);
-    }
+    buildDirectory(config, this);
 
-    this.log("Copying template files");
-    // TODO: Replace any params in files with .template extensions
-    this.copyFiles(this.templateDir, config.outputDir);
-
-    this.log("Success!");
-    // TODO: Can we do this here?
-    this.log("Run ./script/setup to get started");
     this.log(
       "To migrate existing stacks into your new directory you can run cdk-cli migrate"
     );
     this.log("To create a new stack run cdk-cli new");
-  }
-
-  copyFiles(sourcePath: string, targetPath: string): void {
-    for (const file of readdirSync(sourcePath)) {
-      const path = join(sourcePath, file);
-
-      if (path.endsWith(".ignore")) {
-        continue;
-      } else if (lstatSync(path).isDirectory()) {
-        const nestedTargetPath = join(targetPath, file);
-        if (!existsSync(nestedTargetPath)) {
-          mkdirSync(nestedTargetPath);
-        }
-        this.copyFiles(path, nestedTargetPath);
-      } else if (path.endsWith(".template")) {
-        copyFileSync(path, join(targetPath, file.replace(".template", "")));
-      } else {
-        copyFileSync(path, join(targetPath, file));
-      }
-    }
   }
 }

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -19,6 +19,7 @@ describe("The MigrateCommand class", () => {
       },
       flags: {
         "multi-app": false,
+        init: false,
       },
     };
 
@@ -49,7 +50,10 @@ describe("The MigrateCommand class", () => {
 
     test("pulls outs computed values correctly if multiApp is true", () => {
       expect(
-        MigrateCommand.getConfig({ ...args, flags: { "multi-app": true } })
+        MigrateCommand.getConfig({
+          ...args,
+          flags: { "multi-app": true, init: false },
+        })
       ).toMatchObject({
         cfnFile: "template.ts",
         appPath: `/path/to/output/bin/app.ts`,
@@ -67,6 +71,7 @@ describe("The MigrateCommand class", () => {
         },
         flags: {
           "multi-app": false,
+          init: false,
         },
       };
 

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -18,6 +18,7 @@ describe("The NewCommand class", () => {
       },
       flags: {
         "multi-app": false,
+        init: false,
       },
     };
 
@@ -46,7 +47,10 @@ describe("The NewCommand class", () => {
 
     test("pulls outs computed values correctly if multiApp is true", () => {
       expect(
-        NewCommand.getConfig({ ...args, flags: { "multi-app": true } })
+        NewCommand.getConfig({
+          ...args,
+          flags: { "multi-app": true, init: false },
+        })
       ).toMatchObject({
         appPath: `/path/to/output/bin/app.ts`,
         stackPath: `/path/to/output/lib/app/stack-name.ts`,

--- a/src/utils/init.test.ts
+++ b/src/utils/init.test.ts
@@ -1,0 +1,17 @@
+import { ProjectBuilder } from "./init";
+
+describe("The ProjectBuilder class", () => {
+  describe("validateConfig function", () => {
+    test("throws an error if the directory is not empty", () => {
+      expect(() =>
+        ProjectBuilder.validateConfig({ outputDir: "./src" })
+      ).toThrow();
+    });
+
+    test("does not throw an error if the directory is empty", () => {
+      expect(() =>
+        ProjectBuilder.validateConfig({ outputDir: "./src/empty" })
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,0 +1,73 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+} from "fs";
+import { join } from "path";
+import type Command from "@oclif/command";
+import { checkDirectoryIsEmpty } from "../utils/args";
+
+export interface InitConfig {
+  outputDir: string;
+}
+
+// TODO: Add yarn or npm flag
+// TODO: Add project name flag
+export class ProjectBuilder {
+  templateDir = `${__dirname}/../template`;
+  config: InitConfig;
+  command: Command;
+
+  static validateConfig = (config: InitConfig): void => {
+    checkDirectoryIsEmpty(config.outputDir);
+  };
+
+  constructor(config: InitConfig, command: Command) {
+    this.config = config;
+    this.command = command;
+  }
+
+  buildDirectory(): void {
+    ProjectBuilder.validateConfig(this.config);
+
+    if (!existsSync(this.config.outputDir)) {
+      this.command.log(`Creating ${this.config.outputDir}`);
+      mkdirSync(this.config.outputDir);
+    }
+
+    this.command.log("Copying template files");
+    // TODO: Replace any params in files with .template extensions
+    this.copyFiles(this.templateDir, this.config.outputDir);
+
+    this.command.log("Success!");
+    // TODO: Can we do this here?
+    this.command.log("Run ./script/setup to install dependencies");
+  }
+
+  copyFiles(sourcePath: string, targetPath: string): void {
+    for (const file of readdirSync(sourcePath)) {
+      const path = join(sourcePath, file);
+
+      if (path.endsWith(".ignore")) {
+        continue;
+      } else if (lstatSync(path).isDirectory()) {
+        const nestedTargetPath = join(targetPath, file);
+        if (!existsSync(nestedTargetPath)) {
+          mkdirSync(nestedTargetPath);
+        }
+        this.copyFiles(path, nestedTargetPath);
+      } else if (path.endsWith(".template")) {
+        copyFileSync(path, join(targetPath, file.replace(".template", "")));
+      } else {
+        copyFileSync(path, join(targetPath, file));
+      }
+    }
+  }
+}
+
+export const buildDirectory = (config: InitConfig, command: Command): void => {
+  const builder = new ProjectBuilder(config, command);
+  builder.buildDirectory();
+};


### PR DESCRIPTION
## What does this change?

This PR links the functionality of the new and migrate commands with the init command to allow both steps to be done in one command. The first step of this work was refactoring the bulk of the initialisation logic into a new class in the `utils/init.ts` file. An `--init` flag was then added to both the `new` and `migrate` command. If this flag is passed in then the `cdk` project directory is created before the rest of the command is executed.

## How to test

Try running the `new` and `migrate` commands both with and without the `--init` flag appended to see the project directory being created.

## How can we measure success?

Users don't have to run the `init` command followed by either the `new` or `migrate` commands when starting a new cdk project.

## Have we considered potential risks?

There is some risk when running commands that interact with the filesystem but validation has been added to check if files and directories already exist before taking any action.
