### PR TITLE
chore: Add prefix to dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps): "
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps): "
   - package-ecosystem: "npm"
     directory: "/src/template"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps): "


### PR DESCRIPTION
## What does this change?

Inspired by https://github.com/guardian/cdk/pull/224, this PR adds the `chore(deps): ` prefix to dependabot commits because:

1) It's the first step towards automating releases
2) It's a nice to have anyway

## How to test

Wait for the next round of dependabot PRs and see that they have the correct prefix

## How can we measure success?

Dependabot PRs match the pattern required for semantic release

