### PR TITLE
chore: Tell dependabot to ignore `aws-cdk` deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,19 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
+    # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "@aws-cdk"
+      - dependency-name: "@aws-cdk/*"
   - package-ecosystem: "npm"
     directory: "/src/template"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps): "
+    # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "@aws-cdk"
+      - dependency-name: "@aws-cdk/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
-      - dependency-name: "@aws-cdk"
+      - dependency-name: "aws-cdk"
       - dependency-name: "@aws-cdk/*"
   - package-ecosystem: "npm"
     directory: "/src/template"
@@ -28,5 +28,5 @@ updates:
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
-      - dependency-name: "@aws-cdk"
+      - dependency-name: "aws-cdk"
       - dependency-name: "@aws-cdk/*"


### PR DESCRIPTION
## What does this change?

This PR updates the dependabot config so that it ignores updates to the `aws-cdk` libs. As we must stay in line with the currently installed version of `@guardian/cdk`, there's not point having dependabot open these PRs for us.

## How to test

Wait and hope that dependabot doesn't open any more PRs for `aws-cdk` libs.

## How can we measure success?

No more dependabot PRs that we just close each time.