### PR TITLE
chore(deps): update cdk libs to 1.90.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/guardian/cdk-cli/issues",
   "dependencies": {
-    "@aws-cdk/core": "^1.86.0",
+    "@aws-cdk/core": "1.90.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",

--- a/src/template/package.json
+++ b/src/template/package.json
@@ -13,13 +13,13 @@
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.86.0",
+    "@aws-cdk/assert": "1.90.0",
     "@guardian/eslint-config-typescript": "^0.5.0",
     "@types/jest": "^26.0.20",
     "@types/node": "14.14.31",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
-    "aws-cdk": "1.86.0",
+    "aws-cdk": "1.90.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
@@ -32,12 +32,12 @@
     "typescript": "~4.2.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "1.86.0",
-    "@aws-cdk/aws-events-targets": "1.86.0",
-    "@aws-cdk/aws-iam": "1.86.0",
-    "@aws-cdk/aws-lambda": "1.86.0",
-    "@aws-cdk/aws-s3": "1.86.0",
-    "@aws-cdk/core": "1.86.0",
+    "@aws-cdk/aws-ec2": "1.90.0",
+    "@aws-cdk/aws-events-targets": "1.90.0",
+    "@aws-cdk/aws-iam": "1.90.0",
+    "@aws-cdk/aws-lambda": "1.90.0",
+    "@aws-cdk/aws-s3": "1.90.0",
+    "@aws-cdk/core": "1.90.0",
     "@guardian/cdk": "0.39.1",
     "source-map-support": "^0.5.16"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,40 +2,40 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/cloud-assembly-schema@1.86.0":
-  version "1.86.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.86.0.tgz#9bdba964c2d0d2264876f96f540d09c6fcd1c3ff"
-  integrity sha512-3EKvoirgB+2dIX83Pdbi0QUh0JJuYkIssB+KnnCncRZDTl4NU1mlzJtAbZACPJjI7NCJOAxuAS/h+m5LulIqIQ==
+"@aws-cdk/cloud-assembly-schema@1.90.0":
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.90.0.tgz#a0384d5d5adc1773b31eb422d00227de5b7cb077"
+  integrity sha512-BJhVHVIL/Lfx+F2XNhpZm3ZhmN2XhN1tjVGAMexFa+RId6fWasjjaiJug4DwgYoYuHhXqB+3rkB4ojr/cFhD4g==
   dependencies:
     jsonschema "^1.4.0"
-    semver "^7.3.2"
+    semver "^7.3.4"
 
-"@aws-cdk/core@^1.86.0":
-  version "1.86.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.86.0.tgz#b510fd60d30cfae68fd28593cf102de5f63c6f78"
-  integrity sha512-3wdvXta/XU2nKVxpr3rFJ0gKAVfiLuNp7nrarh/nyC+sS2ZtOLNOuHG8Zg0Adpzzb4YWqXknz60KLhSDVAAMsQ==
+"@aws-cdk/core@1.90.0":
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.90.0.tgz#fba613a3e82d4fc64b595decb915f6bcf371e6a9"
+  integrity sha512-d3PdHbp2qtDvtfjkV9AvQzU4uE38FdrL+gecESOwKoNmply4+IzXouvtcJAmiU2TC5ALk9PewOmJ+YQskNzKSg==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.86.0"
-    "@aws-cdk/cx-api" "1.86.0"
-    "@aws-cdk/region-info" "1.86.0"
+    "@aws-cdk/cloud-assembly-schema" "1.90.0"
+    "@aws-cdk/cx-api" "1.90.0"
+    "@aws-cdk/region-info" "1.90.0"
     "@balena/dockerignore" "^1.0.2"
     constructs "^3.2.0"
-    fs-extra "^9.0.1"
+    fs-extra "^9.1.0"
     ignore "^5.1.8"
     minimatch "^3.0.4"
 
-"@aws-cdk/cx-api@1.86.0":
-  version "1.86.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.86.0.tgz#b53d479dba02c7d72abbc43777c2f8a151145bbd"
-  integrity sha512-wxPf1VHwl+joIdZ/KPdUnphZ8VWpL9BuzXGv6ZZXKACsSOh71AD0Hs4XQpFB9akNgadbZfESuUOOKNygt8B8KA==
+"@aws-cdk/cx-api@1.90.0":
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.90.0.tgz#fcedd4e98abc23d8709520897c5ce6c3d621fb60"
+  integrity sha512-U8gkkLJmzWPMsrCtAgJ46pDWrQYonrXVRquWo5dQIkPOkqf6Bd0PFJD1XSTqfpJrQCmcRkQjHQuh2BMC55eRVA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.86.0"
-    semver "^7.3.2"
+    "@aws-cdk/cloud-assembly-schema" "1.90.0"
+    semver "^7.3.4"
 
-"@aws-cdk/region-info@1.86.0":
-  version "1.86.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.86.0.tgz#d5bff6718180e769d6b505efe81875ef9ec2d28d"
-  integrity sha512-enKCy9FJSOkySR1ouev6+cXmGFHHc0rkImtr4xESIlfGK17FsdUvBKp7+oW067Q57NXqP4J0jovX57TXMu/v3Q==
+"@aws-cdk/region-info@1.90.0":
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.90.0.tgz#f541a737b7197c59ae5d738258cab5faeee28fd9"
+  integrity sha512-8D9inMCDsq7amjTxhv+j9R7Ef+oNT/8DhjieL/TZIx58SfobISZ5lMl8F/CB90gmuvPz7p3Vfsn8qm9Y3zpBOA==
 
 "@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.12.11"
@@ -4509,6 +4509,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What does this change?

As of https://github.com/guardian/cdk/pull/257, `@guardian/cdk` now requires version `1.90.0` of the CDK libraries. This PR updates the version used here and also in the `package.json` of projects created using the `init` function.

## How to test

Run the `init` function and check that the created project is compatible with the current version of `@guardian/cdk`

## How can we measure success?

Projects created via the `init` function work as expected.