### PR TITLE
chore: Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      # This repository is currently fairly inactive and not being used in the wild. Run Dependabot once a month to reduce the frequency of PRs
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
@@ -22,7 +23,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/src/template"
     schedule:
-      interval: "weekly"
+      # This repository is currently fairly inactive and not being used in the wild. Run Dependabot once a month to reduce the frequency of PRs
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.


### PR DESCRIPTION
This repository is fairly inactive at the moment and not being used "in the wild". Update Dependabot's configuration to run monthly to reduce the frequency of PRs by a quarter and thus require less commitment from the team.