### PR TITLE
feat: Configure Jest to mock GuCDK's tracking tag

### DIFF
--- a/src/template/.gitignore.template
+++ b/src/template/.gitignore.template
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!jest.setup.js
 !eslintrc.js
 *.d.ts
 node_modules

--- a/src/template/jest.config.js
+++ b/src/template/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/src/template/jest.setup.js
+++ b/src/template/jest.setup.js
@@ -1,0 +1,1 @@
+jest.mock("@guardian/cdk/lib/constants/tracking-tag");


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The tracking tag has a value of the version of GuCDK being used. This is different for each new release of GuCDK.

By mocking it, we make the value static within snapshot tests. This makes it easier to apply patch and minor bumps from Dependabot.

See https://github.com/guardian/cdk/blob/main/docs/001-general-usage.md#-mocking-gucdkversion.