### PR TITLE
fix: Allow `.eslintrc.js` to be added to VCS

### DIFF
--- a/src/template/.gitignore.template
+++ b/src/template/.gitignore.template
@@ -1,7 +1,7 @@
 *.js
 !jest.config.js
 !jest.setup.js
-!eslintrc.js
+!.eslintrc.js
 *.d.ts
 node_modules
 dist


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We have a `*.js` rule in `.gitignore` to ensure compiled output from `tsc` doesn't get committed to VCS. We do have some legit `.js` files, such as `jest.config.js`. For these files we add some negations to `.gitignore`, such as `!jest.config.js`.

The negation for the eslint config file is incorrect, resulting in it being excluded from VCS via `*.js`.

This change fixes that - the eslint config file is `.eslintrc.js`, not `eslintrc.js` (note the starting `.`).