### PR TITLE
feat: Create a snapshot test by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3.2.4",
+    "chalk": "^4.1.2",
+    "cli-ux": "^5.6.3",
     "codemaker": "^1.44.0",
     "js-yaml": "^4.1.0",
     "lodash.camelcase": "^4.3.0",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,8 +1,11 @@
 import path, { basename, dirname } from "path";
 import { Command, flags } from "@oclif/command";
+import chalk from "chalk";
+import cli from "cli-ux";
 import kebabCase from "lodash.kebabcase";
 import { constructApp } from "../utils/app";
 import { checkPathDoesNotExist, checkPathExists } from "../utils/args";
+import { execute } from "../utils/exec";
 import {
   newAppImports,
   newStackImports,
@@ -165,5 +168,37 @@ export class NewCommand extends Command {
       outputFile: basename(config.testPath),
       outputDir: dirname(config.stackPath),
     });
+
+    if (config.init) {
+      cli.action.start(
+        chalk.yellow("Installing dependencies. This may take a while...")
+      );
+      await execute("./script/setup", [], { cwd: config.cdkDir });
+      cli.action.stop();
+    }
+
+    // Run `eslint --fix` on the generated files instead of trying to generate code that completely satisfies the linter
+    await execute(
+      "./node_modules/.bin/eslint",
+      [
+        "lib/** bin/**",
+        "--ext .ts",
+        "--no-error-on-unmatched-pattern",
+        "--fix",
+      ],
+      {
+        cwd: config.cdkDir,
+      }
+    );
+
+    cli.action.start(chalk.yellow("Running tests..."));
+    await execute("./script/test", [], { cwd: config.cdkDir });
+    cli.action.stop();
+
+    this.log(chalk.green("Summarising the created files"));
+    const tree = await execute("tree", ["-I 'node_modules|cdk.out'"], {
+      cwd: config.cdkDir,
+    });
+    this.log(tree);
   }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -200,5 +200,13 @@ export class NewCommand extends Command {
       cwd: config.cdkDir,
     });
     this.log(tree);
+
+    this.log("Project successfully created! Next steps:");
+
+    [
+      "Run ./script/diff to confirm there are no destructive changes (there should only be tag additions)",
+      "Update the repository's CI configuration to run ./script/ci",
+      "Raise a PR with these changes",
+    ].map((step) => this.log(`  - ${step}`));
   }
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,29 @@
+/* eslint-disable -- copied from https://github.com/aws/aws-cdk/blob/eda1640fcaf6375d7edc5f8edcb5d69c82d130a1/packages/aws-cdk/lib/init.ts#L381-L404 */
+
+import childProcess from "child_process";
+
+export async function execute(
+  cmd: string,
+  args: string[],
+  { cwd }: { cwd: string }
+): Promise<string> {
+  const child = childProcess.spawn(cmd, args, {
+    cwd,
+    shell: true,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  let stdout = "";
+  child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+  return new Promise<string>((ok, fail) => {
+    child.once("error", (err) => fail(err));
+    child.once("exit", (status) => {
+      if (status === 0) {
+        return ok(stdout);
+      } else {
+        process.stderr.write(stdout);
+        return fail(new Error(`${cmd} exited with status ${status}`));
+      }
+    });
+  });
+}

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -42,8 +42,6 @@ export class ProjectBuilder {
     this.copyFiles(this.templateDir, this.config.outputDir);
 
     this.command.log("Success!");
-    // TODO: Can we do this here?
-    this.command.log("Run ./script/setup to install dependencies");
   }
 
   copyFiles(sourcePath: string, targetPath: string): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,7 +1332,7 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1375,7 +1375,7 @@ cli-progress@^3.4.0:
     colors "^1.1.2"
     string-width "^4.2.0"
 
-cli-ux@^5.2.1:
+cli-ux@^5.2.1, cli-ux@^5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.3.tgz#eecdb2e0261171f2b28f2be6b18c490291c3a287"
   integrity sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==


### PR DESCRIPTION
Follows #249 .

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Reduces the number of post-run steps by:
  - Auto installing dependencies
  - Creating a base Jest snapshot for a stack

We also `lint --fix` our generated code to ensure it's correctly formatted. Doing this is easier than keeping up to date with our linting rules.

<details>
<summary>Example</summary>

```console
➜ rm -rf cdk && ./bin/run new --init --stack deploy --app amigo --yaml-template-location cfn.yaml --output cdk
Starting CDK generator
Creating cdk
Copying template files
Success!
New app Amigo will be written to cdk/bin/amigo.ts
New stack Deploy will be written to cdk/lib/amigo.ts
Installing dependencies. This may take a while...... ⣽
Installing dependencies. This may take a while...... ⣻
warning " > @aws-cdk/cloudformation-include@1.132.0" has unmet peer dependency "@aws-cdk/aws-acmpca@1.132.0".
warning " > @aws-cdk/cloudformation-include@1.132.0" has unmet peer dependency "@aws-cdk/aws-amazonmq@1.132.0".
warning " > @aws-cdk/cloudformation-include@1.132.0" has unmet peer dependency "@aws-cdk/aws-amplify@1.132.0".
warning " > @aws-cdk/cloudformation-include@1.132.0" has unmet peer dependency "@aws-cdk/aws-apigateway@1.132.0".
warning " > @aws-cdk/cloudformation-include@1.132.0" has unmet peer dependency "@aws-cdk/aws-apigatewayv2@1.132.0".

...trimmed yarn install output

warning "@guardian/cdk > @aws-cdk/aws-lambda-event-sources@1.132.0" has unmet peer dependency "@aws-cdk/aws-s3-notifications@1.132.0".
warning "@guardian/cdk > @aws-cdk/aws-lambda-event-sources@1.132.0" has unmet peer dependency "@aws-cdk/aws-secretsmanager@1.132.0".
warning "@guardian/cdk > @aws-cdk/aws-lambda-event-sources@1.132.0" has unmet peer dependency "@aws-cdk/aws-sns@1.132.0".
warning "@guardian/cdk > @aws-cdk/aws-lambda-event-sources@1.132.0" has unmet peer dependency "@aws-cdk/aws-sns-subscriptions@1.132.0".
warning "@guardian/cdk > @aws-cdk/aws-lambda-event-sources@1.132.0" has unmet peer dependency "@aws-cdk/aws-sqs@1.132.0".
Installing dependencies. This may take a while...... done
Running tests...... ⣽
PASS lib/amigo.test.ts
  The Amigo stack
    ✓ matches the snapshot (189 ms)
Running tests...... ⣻
 › 1 snapshot written.
Snapshot Summary
 › 1 snapshot written from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 written, 1 total
Time:        3.626 s, estimated 5 s
Running tests...... done
Summarising the created files
.
├── README.md
├── bin
│   └── cdk.ts
├── cdk.json
├── jest.config.js
├── jest.setup.js
├── lib
│   ├── __snapshots__
│   │   └── amigo.test.ts.snap
│   ├── amigo.test.ts
│   └── amigo.ts
├── package.json
├── script
│   ├── ci
│   ├── diff
│   ├── lint
│   ├── setup
│   ├── start
│   └── test
├── tsconfig.eslint.json
├── tsconfig.json
└── yarn.lock

4 directories, 18 files
```
</details>

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Create a YAML CFN template (e.g. `cfn.yaml`)
- Run `./bin/run new --init --stack deploy --app amigo --yaml-template-location cfn.yaml --output cdk`
- Observe output similar to above:
  - Dependencies have been installed
  - An initial Jest snapshot has been created
  - A summary of created files is echoed

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer manual steps are needed.