### PR TITLE
feat!: Remove `output` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ OPTIONS
   --multi-app                                      Create the stack files within sub directories as the project defines
                                                    multiple apps (defaults to false)
 
-  --output=output                                  [default: /Users/akash_askoolum/code/cdk-cli/src/commands/cdk] The
-                                                   CDK directory to create the new files in
-
   --stack=stack                                    (required) The Guardian stack being used (as defined in your
                                                    riff-raff.yaml). This will be applied as a tag to all of your
                                                    resources.

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { NewCommand } from "./new";
 
 describe("The NewCommand class", () => {
@@ -11,18 +12,17 @@ describe("The NewCommand class", () => {
     });
 
     const args = {
-      flags: {
-        "multi-app": false,
-        init: false,
-        output: "/path/to/output",
-        app: "App",
-        stack: "StackName",
-      },
+      "multi-app": false,
+      init: false,
+      app: "App",
+      stack: "StackName",
     };
 
-    test("pulls outs direct args correctly", () => {
-      expect(NewCommand.getConfig(args)).toMatchObject({
-        cdkDir: "/path/to/output",
+    const repoRoot = path.join(__dirname, "../..");
+
+    test("pulls outs direct args correctly", async () => {
+      expect(await NewCommand.getConfig(args)).toMatchObject({
+        cdkDir: path.join(repoRoot, "cdk"),
         multiApp: false,
         appName: {
           pascal: "App",
@@ -35,29 +35,26 @@ describe("The NewCommand class", () => {
       });
     });
 
-    test("pulls outs computed values correctly", () => {
-      expect(NewCommand.getConfig(args)).toMatchObject({
-        appPath: `/path/to/output/bin/app.ts`,
-        stackPath: `/path/to/output/lib/app.ts`,
-        testPath: `/path/to/output/lib/app.test.ts`,
+    test("pulls outs computed values correctly", async () => {
+      expect(await NewCommand.getConfig(args)).toMatchObject({
+        appPath: path.join(repoRoot, "cdk", "bin", "app.ts"),
+        stackPath: path.join(repoRoot, "cdk", "lib", "app.ts"),
+        testPath: path.join(repoRoot, "cdk", "lib", "app.test.ts"),
       });
     });
 
-    test("pulls outs computed values correctly if multiApp is true", () => {
+    test("pulls outs computed values correctly if multiApp is true", async () => {
       expect(
-        NewCommand.getConfig({
-          flags: {
-            "multi-app": true,
-            init: false,
-            output: "/path/to/output",
-            app: "App",
-            stack: "StackName",
-          },
+        await NewCommand.getConfig({
+          "multi-app": true,
+          init: false,
+          app: "App",
+          stack: "StackName",
         })
       ).toMatchObject({
-        appPath: `/path/to/output/bin/app.ts`,
-        stackPath: `/path/to/output/lib/app/app.ts`,
-        testPath: `/path/to/output/lib/app/app.test.ts`,
+        appPath: path.join(repoRoot, "cdk", "bin", "app.ts"),
+        stackPath: path.join(repoRoot, "cdk", "lib", "app", "app.ts"),
+        testPath: path.join(repoRoot, "cdk", "lib", "app", "app.test.ts"),
       });
     });
   });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,23 @@
+import chalk from "chalk";
+import cli from "cli-ux";
+import { execute } from "./exec";
+
+export async function gitRootOrCwd(): Promise<string> {
+  cli.action.start(
+    chalk.yellow("Determining git repository root directory to write into")
+  );
+  try {
+    const gitRoot = await execute("git", ["rev-parse", "--show-toplevel"], {
+      cwd: process.cwd(),
+    });
+    cli.action.stop(`Success! It is ${chalk.green(gitRoot)}`);
+    return gitRoot.trim();
+  } catch (e) {
+    cli.action.stop(
+      `Failed to identify a git repository. Falling back to CWD ${chalk.green(
+        process.cwd()
+      )}`
+    );
+    return Promise.resolve(process.cwd());
+  }
+}


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Rather than accept an `output` location, we automatically create a `cdk` directory in either:
  - the root directory of the git repository
  - the current working directory if we're not a git repository

Installing into a known location helps keep things simple and consistent.

<details>
<summary>Example output when a git directory</summary>

```console
Starting CDK generator
Determining git repository root directory to write into... Success! It is /private/tmp/cli
```

</details>

<details>
<summary>Example output when a non-git directory</summary>

```console
Starting CDK generator
Determining git repository root directory to write into...
Determining git repository root directory to write into... Failed to identify a git repository. Falling back to CWD /private/tmp/cli
```

</details>

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

### git directory
- Move into a scratch location, e.g. `/tmp/cdk-cli-test`
- Initialise the directory as a git repository `git init`
- Run the CLI `~/code/cdk-cli/bin/run new --init --stack deploy --app amigo` and observe output similar to above

### non-git directory
- Move into a scratch location, e.g. `/tmp/cdk-cli-test`
- Run the CLI `~/code/cdk-cli/bin/run new --init --stack deploy --app amigo` and observe output similar to above